### PR TITLE
Add Day 1 RDD vs DataFrame PySpark example

### DIFF
--- a/day1_rdd_basics/Spark_RDD_Basics_Day1.ipynb
+++ b/day1_rdd_basics/Spark_RDD_Basics_Day1.ipynb
@@ -1,0 +1,624 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3a956182-c5b2-46c0-8ea1-2985b7f0ff1e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "🧰 1. Spark Initialization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "47b1df3e-7c39-4679-864d-d5aaae50896f",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "\n",
+    "# Create a Spark session\n",
+    "spark = SparkSession.builder \\\n",
+    "    .appName(\"Spark RDD Basics\") \\\n",
+    "    .getOrCreate()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "fe275ac4-d573-4d6e-8f70-2d997e0227d9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "📂 2. Load Sample Data (Optional CSV)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "bf42a920-da81-4af4-99b1-d853ad7e2e18",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+-------------+-------+----------+------------------------+-----------------------+\n|2014 rank|         City|  State|State Code|2014 Population estimate|2015 median sales price|\n+---------+-------------+-------+----------+------------------------+-----------------------+\n|      101|   Birmingham|Alabama|        AL|                  212247|                  162.9|\n|      125|   Huntsville|Alabama|        AL|                  188226|                  157.7|\n|      122|       Mobile|Alabama|        AL|                  194675|                  122.5|\n|      114|   Montgomery|Alabama|        AL|                  200481|                  129.0|\n|       64|Anchorage[19]| Alaska|        AK|                  301010|                   null|\n+---------+-------------+-------+----------+------------------------+-----------------------+\nonly showing top 5 rows\n\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Example: Load a CSV file into a DataFrame\n",
+    "df = spark.read.csv(\"/databricks-datasets/samples/population-vs-price/data_geo.csv\", header=True, inferSchema=True)\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "1aadda45-230b-47f9-8d2e-2e6828b01a0e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "🔧 3. RDD Basics and Lambda Functions\n",
+    "✅ What is an RDD?\n",
+    "An RDD (Resilient Distributed Dataset) is the fundamental data structure in Spark, representing an immutable distributed collection of objects.\n",
+    "\n",
+    "✅ Lambda Functions in PySpark\n",
+    "Lambda is an anonymous, one-line function often used in transformations like map, filter, and reduce."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "7fd0c250-5494-487b-a5a3-133b0c78196e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "🔁 4. RDD Transformations\n",
+    "\n",
+    "4.1 map() – Apply function to each element"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "4d3cb45c-074c-4a10-a1d0-4ebfb2be46d2",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[66]: [2, 4, 6, 8, 10]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd = spark.sparkContext.parallelize([1, 2, 3, 4, 5])\n",
+    "rdd_map = rdd.map(lambda x: x * 2)\n",
+    "rdd_map.collect()  # [2, 4, 6, 8, 10]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "35f1de2a-d865-40f0-b555-5007448d8168",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "4.2 flatMap() – Flatten the result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "3ff00371-f265-4244-b3d5-2c898b417788",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[67]: ['hello', 'world', 'hi', 'spark']"
+     ]
+    }
+   ],
+   "source": [
+    "rdd = spark.sparkContext.parallelize([\"hello world\", \"hi spark\"])\n",
+    "rdd_flatmap = rdd.flatMap(lambda line: line.split(\" \"))\n",
+    "rdd_flatmap.collect()  # ['hello', 'world', 'hi', 'spark']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "6bf2acbe-25b6-4da5-a1ac-0f595c0b2055",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "4.3 filter() – Filter elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d24e51a2-b71e-4072-a838-9d5bba7c7fa9",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[68]: [2, 4]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd = spark.sparkContext.parallelize([1, 2, 3, 4, 5])\n",
+    "rdd_filter = rdd.filter(lambda x: x % 2 == 0)\n",
+    "rdd_filter.collect()  # [2, 4]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "b8bfb531-03bc-46f9-a65e-e7bcd52a5743",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "4.4 distinct() – Remove duplicates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "63779180-dee7-4b3c-9d42-8c5064dcbcdb",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[69]: [1, 2, 3]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd = spark.sparkContext.parallelize([1, 2, 2, 3])\n",
+    "rdd_distinct = rdd.distinct()\n",
+    "rdd_distinct.collect()  # [1, 2, 3]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "4cda34a9-5b10-4edd-bb07-91165ed62e1e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "4.5 union() – Combine two RDDs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "c8f4856d-dbcb-4a44-b3b2-0291c2f2b13e",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[70]: [1, 2, 3, 4]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd1 = spark.sparkContext.parallelize([1, 2])\n",
+    "rdd2 = spark.sparkContext.parallelize([3, 4])\n",
+    "rdd_union = rdd1.union(rdd2)\n",
+    "rdd_union.collect()  # [1, 2, 3, 4]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "d6fe4f78-ba60-4ae3-ada1-6ee6d61a2abb",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "4.6 intersection() – Common elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "e492dc0d-9d78-4c56-ac9e-f729c965e808",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[71]: [2, 3]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd1 = spark.sparkContext.parallelize([1, 2, 3])\n",
+    "rdd2 = spark.sparkContext.parallelize([2, 3, 4])\n",
+    "rdd1.intersection(rdd2).collect()  # [2, 3]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "f96800f3-c442-4913-98bf-192bd1b122d3",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "🧮 5. Key-Value RDD Operations\n",
+    "\n",
+    "5.1 reduceByKey() – Efficient aggregation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "7ada95de-93fe-4eab-835d-c3b0f0b1c9b8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[72]: [('a', 3), ('b', 3)]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd = spark.sparkContext.parallelize([(\"a\", 1), (\"a\", 2), (\"b\", 3)])\n",
+    "rdd.reduceByKey(lambda x, y: x + y).collect()  # [('a', 3), ('b', 3)]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "ae5695b4-5342-4507-9908-11275f01f0c8",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "5.2 groupByKey() – Group values (⚠️ less efficient)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "394a760b-0719-436f-b1ef-dd72bc4aec94",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out[73]: [('a', [1, 2]), ('b', [3])]"
+     ]
+    }
+   ],
+   "source": [
+    "rdd.groupByKey().mapValues(list).collect()  # [('a', [1, 2]), ('b', [3])]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "2ca17d84-66d0-417d-b143-a48495df9472",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "source": [
+    "✅ 6. RDD Actions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
+     "inputWidgets": {},
+     "nuid": "917e6267-8c5a-491a-bbc4-7d3896d23528",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "collect(): [1, 2, 3, 4]\ncount(): 4\nfirst(): 1\ntake(3): [1, 2, 3]\nreduce(): 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "# RDD Actions\n",
+    "\n",
+    "# Sample RDD\n",
+    "rdd = spark.sparkContext.parallelize([1, 2, 3, 4])\n",
+    "\n",
+    "# 6.1 collect() – Brings all elements to the driver (avoid for large datasets)\n",
+    "print(\"collect():\", rdd.collect())\n",
+    "\n",
+    "# 6.2 count() – Number of elements\n",
+    "print(\"count():\", rdd.count())\n",
+    "\n",
+    "# 6.3 first() – First element\n",
+    "print(\"first():\", rdd.first())\n",
+    "\n",
+    "# 6.4 take(n) – First n elements\n",
+    "print(\"take(3):\", rdd.take(3))\n",
+    "\n",
+    "# 6.5 reduce() – Combine all elements using a function\n",
+    "print(\"reduce():\", rdd.reduce(lambda x, y: x + y))\n",
+    "\n",
+    "# 6.6 foreach() – Apply function to each element (prints on worker nodes)\n",
+    "# Note: Output might not appear in notebook UI depending on the Spark cluster behavior\n",
+    "rdd.foreach(lambda x: print(f\"foreach(): {x}\"))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "application/vnd.databricks.v1+notebook": {
+   "computePreferences": null,
+   "dashboards": [],
+   "environmentMetadata": {
+    "base_environment": "",
+    "environment_version": "1"
+   },
+   "inputWidgetPreferences": null,
+   "language": "python",
+   "notebookMetadata": {
+    "pythonIndentUnit": 4
+   },
+   "notebookName": "Spark_RDD_Basics_Day1",
+   "widgets": {}
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
# PySpark Interview Prep - 7 Day Tracker

This repository contains a structured 7-day preparation plan for PySpark interviews. It includes:

- Daily topics and focus areas
- Hands-on PySpark code (RDDs, DataFrames, joins, UDFs, Delta Lake)
- Interview-style Q&A
- Practice tasks with real-time scenarios

## 🗓️ Day 1: Spark Basics
- RDD vs DataFrame
- Lazy Evaluation
- DAG Execution
- SparkSession

✅ Code: `day1_rdd_basics/rdd_vs_df.py`
✅ Notes: `day1_rdd_basics/rdd_notes.md`
